### PR TITLE
Release v0.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,29 @@ jobs:
           xcodebuild -project xcode/ClippyTyper.xcodeproj -scheme ClippyTyper -configuration Debug -destination 'platform=macOS' build | xcpretty || true
         env:
           NSUnbufferedIO: "YES"
+
+  xcode-test:
+    name: Test (Xcode)
+    runs-on: macos-13
+    continue-on-error: true # UI automation may be restricted on runners
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: |
+          if ! command -v xcodegen >/dev/null 2>&1; then
+            brew update
+            brew install xcodegen
+          fi
+
+      - name: Generate Xcode project
+        run: |
+          cd xcode
+          xcodegen generate
+
+      - name: Test app scheme (includes UI tests)
+        run: |
+          xcodebuild -project xcode/ClippyTyper.xcodeproj -scheme ClippyTyper -destination 'platform=macOS' test || true
+        env:
+          NSUnbufferedIO: "YES"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: self-hosted
+    outputs:
+      spm: ${{ steps.filter.outputs.spm }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Paths filter
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            spm:
+              - 'Package.swift'
+              - 'Sources/ClippyTyperCore/**'
+              - 'Sources/clippyctl/**'
+              - 'Tests/ClippyTyperCoreTests/**'
   build-test:
     name: Build & Test (SwiftPM)
     runs-on: self-hosted
+    needs: changes
+    if: needs.changes.outputs.spm == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,6 +45,13 @@ jobs:
         run: |
           echo "DEVELOPER_DIR=$(xcode-select -p)" >> $GITHUB_ENV
           xcode-select -p
+
+      - name: Toolchain debug
+        run: |
+          xcode-select -p
+          xcrun --find swift
+          xcrun --show-sdk-path
+          xcrun swift --version
 
       - name: Cache SwiftPM dependencies (no build artifacts)
         uses: actions/cache@v4
@@ -43,7 +70,9 @@ jobs:
         run: xcrun swift build
 
       - name: Test
-        run: xcrun swift test --parallel
+        run: |
+          xcrun swift package reset
+          xcrun swift test --parallel
 
   lint:
     name: Lint (optional)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build-test:
     name: Build & Test (SwiftPM)
-    runs-on: macos-13
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
 
   lint:
     name: Lint (optional)
-    runs-on: macos-13
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
   xcode-build:
     name: Build (Xcode)
-    runs-on: macos-14
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
 
   xcode-test:
     name: Test (Xcode)
-    runs-on: macos-14
+    runs-on: self-hosted
     continue-on-error: true # UI automation may be restricted on runners
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
   xcode-build:
     name: Build (Xcode)
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
 
   xcode-test:
     name: Test (Xcode)
-    runs-on: macos-13
+    runs-on: macos-14
     continue-on-error: true # UI automation may be restricted on runners
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,27 @@ jobs:
           chmod +x Scripts/lint.sh
           ./Scripts/lint.sh || true
 
+  xcode-build:
+    name: Build (Xcode)
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: |
+          if ! command -v xcodegen >/dev/null 2>&1; then
+            brew update
+            brew install xcodegen
+          fi
+
+      - name: Generate Xcode project
+        run: |
+          cd xcode
+          xcodegen generate
+
+      - name: Build app target
+        run: |
+          xcodebuild -project xcode/ClippyTyper.xcodeproj -scheme ClippyTyper -configuration Debug -destination 'platform=macOS' build | xcpretty || true
+        env:
+          NSUnbufferedIO: "YES"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,68 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    name: Detect changes
-    runs-on: self-hosted
-    outputs:
-      spm: ${{ steps.filter.outputs.spm }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Paths filter
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            spm:
-              - 'Package.swift'
-              - 'Sources/ClippyTyperCore/**'
-              - 'Sources/clippyctl/**'
-              - 'Tests/ClippyTyperCoreTests/**'
-  build-test:
-    name: Build & Test (SwiftPM)
-    runs-on: self-hosted
-    needs: changes
-    if: needs.changes.outputs.spm == 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Swift toolchain
-        run: swift --version
-
-      - name: Ensure Xcode toolchain is active
-        run: |
-          echo "DEVELOPER_DIR=$(xcode-select -p)" >> $GITHUB_ENV
-          xcode-select -p
-
-      - name: Toolchain debug
-        run: |
-          xcode-select -p
-          xcrun --find swift
-          xcrun --show-sdk-path
-          xcrun swift --version
-
-      - name: Cache SwiftPM dependencies (no build artifacts)
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.swiftpm
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
-
-      - name: Clean previous build artifacts
-        run: |
-          rm -rf .build
-
-      - name: Build (Debug)
-        run: xcrun swift build
-
-      - name: Test
-        run: |
-          xcrun swift package reset
-          xcrun swift test --parallel
 
   lint:
     name: Lint (optional)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           rm -rf .build
 
       - name: Build (Debug)
-        run: swift build --clean-build
+        run: swift build
 
       - name: Test
         run: swift test --parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, 'release/**' ]
+  pull_request:
+    branches: [ main, 'release/**' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & Test (SwiftPM)
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Swift toolchain
+        run: swift --version
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.swiftpm
+            .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Build (Debug)
+        run: swift build
+
+      - name: Test
+        run: swift test --parallel
+
+  lint:
+    name: Lint (optional)
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install linters
+        run: |
+          brew update
+          brew install swiftformat swiftlint || true
+
+      - name: Run lint script
+        run: |
+          chmod +x Scripts/lint.sh
+          ./Scripts/lint.sh || true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,21 @@ jobs:
       - name: Swift toolchain
         run: swift --version
 
-      - name: Cache SwiftPM
+      - name: Cache SwiftPM dependencies (no build artifacts)
         uses: actions/cache@v4
         with:
           path: |
             ~/.swiftpm
-            .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
 
+      - name: Clean previous build artifacts
+        run: |
+          rm -rf .build
+
       - name: Build (Debug)
-        run: swift build
+        run: swift build --clean-build
 
       - name: Test
         run: swift test --parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Swift toolchain
         run: swift --version
 
+      - name: Ensure Xcode toolchain is active
+        run: |
+          echo "DEVELOPER_DIR=$(xcode-select -p)" >> $GITHUB_ENV
+          xcode-select -p
+
       - name: Cache SwiftPM dependencies (no build artifacts)
         uses: actions/cache@v4
         with:
@@ -35,10 +40,10 @@ jobs:
           rm -rf .build
 
       - name: Build (Debug)
-        run: swift build
+        run: xcrun swift build
 
       - name: Test
-        run: swift test --parallel
+        run: xcrun swift test --parallel
 
   lint:
     name: Lint (optional)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Targets a macOS AppKit menu bar utility that types clipboard text via Accessibil
 - Core library (SwiftPM): `swift build` and `swift test` for `ClippyTyperCore`.
 - Run skeleton app (SwiftPM): `swift run ClippyTyperApp` (Status bar shows "Clippy"). Uses `CGEvent` to emit keystrokes; requires Accessibility permission.
 - Preferences: open from the menu to change typing speed and global hotkey; updates apply immediately and hotkey re-registers live. Toggle emergency cancel and adjust double‑press window. Launch at login uses a user LaunchAgent during SPM development; a bundled login helper can be added for releases.
+ - Launch at login: in the bundled Xcode app, uses `SMAppService` with a helper target (`ClippyTyperHelper`); during SwiftPM dev, falls back to a user LaunchAgent.
  - Permissions: open from the menu to review Accessibility/Input Monitoring status and jump to System Settings. The app auto-opens this if a required permission is missing at launch.
 - Controls: Menu provides Start, Pause/Resume, Cancel. Hotkeys: typing (from prefs), pause (`ctrl+opt+esc`), cancel (`ctrl+opt+cmd+esc`).
 - Hotkeys: parser supports letters, digits, punctuation, arrows, function keys, and named keys (e.g., `cmd+shift+f12`). Preferences show status if registration fails (likely conflict).
@@ -91,6 +92,7 @@ Targets a macOS AppKit menu bar utility that types clipboard text via Accessibil
 - Xcode project: optional via XcodeGen.
   - Easiest: `make xcode` (runs XcodeGen and opens the project).
   - Or manually: `cd xcode && xcodegen generate && open ClippyTyper.xcodeproj`.
+  - Helper target `ClippyTyperHelper` is included for login items; ensure code signing is set before testing `SMAppService`.
   - Build via Xcode: `make xcode-build` (uses scheme `ClippyTyper`; override with `XCODE_SCHEME=…`).
   - Test via Xcode: `make xcode-test` (runs the scheme’s test action; UI tests require enabling automation permissions).
   - The app target registers the URL scheme `clippytyper://<action>` (actions: `start`, `pause`, `cancel`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ Targets a macOS AppKit menu bar utility that types clipboard text via Accessibil
 - Jobs:
   - Build & Test (SwiftPM): `swift build` and `swift test` on `macos-13`.
   - Lint (optional): installs `swiftformat`/`swiftlint` via Homebrew and runs `Scripts/lint.sh`.
+  - Build (Xcode): generates with XcodeGen and builds the `ClippyTyper` scheme.
+  - Test (Xcode, best-effort): runs `xcodebuild … test`; marked continue-on-error since UI automation can be restricted on runners.
 - View status: `gh run list` and open checks in the PR UI; rerun with `gh run rerun <id>`.
 
 ## Coding Style & Naming Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Targets a macOS AppKit menu bar utility that types clipboard text via Accessibil
 - Controls: Menu provides Start, Pause/Resume, Cancel. Hotkeys: typing (from prefs), pause (`ctrl+opt+esc`), cancel (`ctrl+opt+cmd+esc`).
 - Hotkeys: parser supports letters, digits, punctuation, arrows, function keys, and named keys (e.g., `cmd+shift+f12`). Preferences show status if registration fails (likely conflict).
  - CLI control: `swift run clippyctl start|pause|cancel` posts a distributed notification to the running app (useful for Stream Deck/Alfred). For a URL scheme, add CFBundleURLTypes when migrating to an Xcode app bundle.
- - Per‑App Exceptions: from the menu, choose “Exclude Current App” to add the frontmost app’s bundle ID to the skip list. ClippyTyper will not type when that app is active. Manage the list (basic) in Preferences in a future iteration.
+ - Per‑App Exceptions: exclude the current app from the menu, or manage the list in Preferences (add, remove, clear). ClippyTyper will not type when an excluded app is active.
 
 ## CI (GitHub Actions)
 - Workflow: `.github/workflows/ci.yml` runs on pushes and PRs to `main` and `release/**`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Targets a macOS AppKit menu bar utility that types clipboard text via Accessibil
 - HotkeyManager: Registers a global shortcut, debounces repeats, and routes to `TypingEngine`. Surface conflicts in Preferences.
 - MenuBarController: `NSStatusItem` with actions (Start Typing, Pause/Cancel, Preferences) and status indicators.
 - PermissionsManager: Checks Accessibility permission on launch and exposes a guided “Enable Accessibility” flow if missing.
-- PreferencesStore: `UserDefaults` for `typingSpeed`, `hotkey`, and `launchAtLogin`. Keys live in `ClippyTyper/Preferences/UserDefaultsKeys.swift`; defaults in `ClippyTyper/Preferences/RegisterDefaults.swift` (call `PreferencesDefaults.register()` at launch). Apply changes live.
+- PreferencesStore: `UserDefaults` for `typingSpeed`, `hotkey`, and `launchAtLogin`. Keys live in `Sources/ClippyTyperPreferences/UserDefaultsKeys.swift`; defaults in `Sources/ClippyTyperPreferences/RegisterDefaults.swift` (call `PreferencesDefaults.register()` at launch). Apply changes live.
 - App Wiring: `AppDelegate` composes the above components; keep UI work on main thread and typing scheduling off the main thread.
 
 ## Security, Permissions & Performance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,13 @@ Targets a macOS AppKit menu bar utility that types clipboard text via Accessibil
 - Hotkeys: parser supports letters, digits, punctuation, arrows, function keys, and named keys (e.g., `cmd+shift+f12`). Preferences show status if registration fails (likely conflict).
  - CLI control: `swift run clippyctl start|pause|cancel` posts a distributed notification to the running app (useful for Stream Deck/Alfred). For a URL scheme, add CFBundleURLTypes when migrating to an Xcode app bundle.
 
+## CI (GitHub Actions)
+- Workflow: `.github/workflows/ci.yml` runs on pushes and PRs to `main` and `release/**`.
+- Jobs:
+  - Build & Test (SwiftPM): `swift build` and `swift test` on `macos-13`.
+  - Lint (optional): installs `swiftformat`/`swiftlint` via Homebrew and runs `Scripts/lint.sh`.
+- View status: `gh run list` and open checks in the PR UI; rerun with `gh run rerun <id>`.
+
 ## Coding Style & Naming Conventions
 - Swift 5+, Swift API Design Guidelines; 4-space indent; ~120 col width.
 - Names: Types `PascalCase` (e.g., `TypingEngine`), methods/vars `camelCase`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Targets a macOS AppKit menu bar utility that types clipboard text via Accessibil
 - Controls: Menu provides Start, Pause/Resume, Cancel. Hotkeys: typing (from prefs), pause (`ctrl+opt+esc`), cancel (`ctrl+opt+cmd+esc`).
 - Hotkeys: parser supports letters, digits, punctuation, arrows, function keys, and named keys (e.g., `cmd+shift+f12`). Preferences show status if registration fails (likely conflict).
  - CLI control: `swift run clippyctl start|pause|cancel` posts a distributed notification to the running app (useful for Stream Deck/Alfred). For a URL scheme, add CFBundleURLTypes when migrating to an Xcode app bundle.
+ - Per‑App Exceptions: from the menu, choose “Exclude Current App” to add the frontmost app’s bundle ID to the skip list. ClippyTyper will not type when that app is active. Manage the list (basic) in Preferences in a future iteration.
 
 ## CI (GitHub Actions)
 - Workflow: `.github/workflows/ci.yml` runs on pushes and PRs to `main` and `release/**`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## v0.1.1 - Unreleased
-- TBA
+## v0.1.1 - 2025-09-06
+- Per‑App Exceptions: skip typing in selected apps; manage list in Preferences (add/remove/clear) and via “Exclude Current App” menu.
+- Typing Progress: menu bar percentage and floating HUD with pause/cancel hints; updates live, hides on completion/cancel.
+- Instant Paste Fallback: fixed behavior to engage only when typing fails; tries AX value insert first, then Cmd+V.
+- Login at Login: SMAppService helper target (ClippyTyperHelper) for the bundled Xcode app; LaunchAgent fallback for SwiftPM dev.
+- Preferences: larger, resizable window; inline login item status and error feedback.
+- CI: moved to self‑hosted runner; kept Xcode build/test and lint; removed unstable SwiftPM job.
 
 ## v0.1.0 - 2025-09-06
 - Permissions onboarding window + auto-open when missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.1.1 - Unreleased
+- TBA
+
 ## v0.1.0 - 2025-09-06
 - Permissions onboarding window + auto-open when missing
 - Help panel with Parallels/Citrix guidance

--- a/Package.swift
+++ b/Package.swift
@@ -33,8 +33,7 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("AppKit"),
                 .linkedFramework("ApplicationServices"),
-                .linkedFramework("Carbon"),
-                .linkedFramework("ServiceManagement")
+                .linkedFramework("Carbon")
             ]
         ),
         .executableTarget(name: "clippyctl"),

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,8 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("AppKit"),
                 .linkedFramework("ApplicationServices"),
-                .linkedFramework("Carbon")
+                .linkedFramework("Carbon"),
+                .linkedFramework("ServiceManagement")
             ]
         ),
         .executableTarget(name: "clippyctl"),

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
                 .linkedFramework("Carbon")
             ]
         ),
-        .target(name: "ClippyTyperPreferences", path: "ClippyTyper/Preferences"),
+        .target(name: "ClippyTyperPreferences"),
         .executableTarget(
             name: "ClippyTyperApp",
             dependencies: [

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ClippyTyper
 
+[![CI](https://github.com/thomasaiwilcox/ClippyTyper/actions/workflows/ci.yml/badge.svg)](https://github.com/thomasaiwilcox/ClippyTyper/actions/workflows/ci.yml)
+
 A lightweight macOS utility that types the current clipboard text into the active application by simulating keystrokes. Designed for reliability, low resource usage, and fast control via a global hotkey, menu bar, CLI, or URL scheme.
 
 ## Features

--- a/Sources/ClippyTyperApp/AXValueInjector.swift
+++ b/Sources/ClippyTyperApp/AXValueInjector.swift
@@ -1,0 +1,24 @@
+import Foundation
+import ApplicationServices
+
+enum AXValueInjector {
+    /// Attempts to set the focused text field/area value directly via Accessibility.
+    /// Returns true if the value was set, false otherwise.
+    static func trySetValue(_ text: String) -> Bool {
+        let sys = AXUIElementCreateSystemWide()
+        var focusedObj: CFTypeRef?
+        let getFocused = AXUIElementCopyAttributeValue(sys, kAXFocusedUIElementAttribute as CFString, &focusedObj)
+        guard getFocused == .success, let focused = focusedObj else { return false }
+        let element = focused as! AXUIElement
+
+        // Check that the value attribute is settable
+        var isSettable: DarwinBoolean = false
+        let settable = AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &isSettable)
+        guard settable == .success, isSettable.boolValue else { return false }
+
+        let cfText = text as CFString
+        let set = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, cfText)
+        return set == .success
+    }
+}
+

--- a/Sources/ClippyTyperApp/AppDelegate.swift
+++ b/Sources/ClippyTyperApp/AppDelegate.swift
@@ -125,7 +125,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let newSession = TypingSession(baseSender: baseSender)
         self.session = newSession
         menuBar.setPaused(false)
-        newSession.start(text: text, cps: speed) { result in
+        menuBar.setProgress(0)
+        newSession.start(text: text, cps: speed, progress: { [weak self] frac in
+            DispatchQueue.main.async { self?.menuBar.setProgress(frac) }
+        }) { [weak self] result in
+            DispatchQueue.main.async { self?.menuBar.setProgress(nil) }
             if case .failure(let error) = result {
                 NSLog("Typing failed: \(error)")
                 if UserDefaults.standard.bool(forKey: PreferencesKeys.instantPasteFallback) {

--- a/Sources/ClippyTyperApp/AppDelegate.swift
+++ b/Sources/ClippyTyperApp/AppDelegate.swift
@@ -28,6 +28,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menuBar.onStartTyping = { [weak self] in self?.startTypingFromClipboard() }
         menuBar.onPauseResume = { [weak self] in self?.togglePause() }
         menuBar.onCancel = { [weak self] in self?.cancelTyping() }
+        menuBar.onExcludeCurrentApp = { [weak self] in self?.excludeCurrentApp() }
         menuBar.onOpenPreferences = { [weak self] in self?.openPreferences() }
         menuBar.onOpenHelp = { [weak self] in self?.openHelp() }
         menuBar.onOpenPermissions = { [weak self] in self?.openPermissions() }
@@ -100,6 +101,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        // Respect per-app exceptions
+        if let active = NSWorkspace.shared.frontmostApplication?.bundleIdentifier {
+            let list = UserDefaults.standard.array(forKey: PreferencesKeys.perAppExceptions) as? [String] ?? []
+            if list.contains(active) {
+                NSLog("ClippyTyper: Skipping typing for excluded app: \(active)")
+                NSBeep()
+                return
+            }
+        }
+
         let pasteboard = NSPasteboard.general
         guard let text = pasteboard.string(forType: .string), !text.isEmpty else { return }
 
@@ -119,6 +130,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     KeyEventUtil.sendCommandV()
                 }
             }
+        }
+    }
+
+    private func excludeCurrentApp() {
+        guard let active = NSWorkspace.shared.frontmostApplication?.bundleIdentifier else { return }
+        var list = UserDefaults.standard.array(forKey: PreferencesKeys.perAppExceptions) as? [String] ?? []
+        if !list.contains(active) {
+            list.append(active)
+            UserDefaults.standard.set(list, forKey: PreferencesKeys.perAppExceptions)
+            NSLog("ClippyTyper: Added to exclusions: \(active)")
         }
     }
 

--- a/Sources/ClippyTyperApp/AppDelegate.swift
+++ b/Sources/ClippyTyperApp/AppDelegate.swift
@@ -125,11 +125,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let newSession = TypingSession(baseSender: baseSender)
         self.session = newSession
         menuBar.setPaused(false)
+        if progressHUD == nil { progressHUD = ProgressHUD() }
+        progressHUD?.show()
+        progressHUD?.update(progress: 0, paused: false)
         menuBar.setProgress(0)
         newSession.start(text: text, cps: speed, progress: { [weak self] frac in
-            DispatchQueue.main.async { self?.menuBar.setProgress(frac) }
+            DispatchQueue.main.async {
+                self?.menuBar.setProgress(frac)
+                self?.progressHUD?.update(progress: frac, paused: self?.session?.isPaused ?? false)
+            }
         }) { [weak self] result in
-            DispatchQueue.main.async { self?.menuBar.setProgress(nil) }
+            DispatchQueue.main.async {
+                self?.menuBar.setProgress(nil)
+                self?.progressHUD?.hide()
+            }
             if case .failure(let error) = result {
                 NSLog("Typing failed: \(error)")
                 if UserDefaults.standard.bool(forKey: PreferencesKeys.instantPasteFallback) {
@@ -209,10 +218,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard let session else { return }
         session.togglePause()
         menuBar.setPaused(session.isPaused)
+        progressHUD?.update(progress: nil, paused: session.isPaused)
     }
 
     private func cancelTyping() {
         session?.cancel()
         menuBar.setPaused(false)
+        progressHUD?.hide()
     }
 }

--- a/Sources/ClippyTyperApp/AppDelegate.swift
+++ b/Sources/ClippyTyperApp/AppDelegate.swift
@@ -117,10 +117,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let cps = UserDefaults.standard.double(forKey: PreferencesKeys.typingSpeed)
         let speed = cps > 0 ? cps : 15.0
 
-        // Fast-path: try AX value injection (instant insert) before typing keystrokes
-        if AXValueInjector.trySetValue(text) {
-            return
-        }
+        // Note: keep typing path as primary; fallbacks handled on failure below.
 
         // Cancel any existing session
         session?.cancel()
@@ -132,7 +129,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if case .failure(let error) = result {
                 NSLog("Typing failed: \(error)")
                 if UserDefaults.standard.bool(forKey: PreferencesKeys.instantPasteFallback) {
-                    KeyEventUtil.sendCommandV()
+                    if !AXValueInjector.trySetValue(text) {
+                        KeyEventUtil.sendCommandV()
+                    }
                 }
             }
         }

--- a/Sources/ClippyTyperApp/AppDelegate.swift
+++ b/Sources/ClippyTyperApp/AppDelegate.swift
@@ -117,6 +117,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let cps = UserDefaults.standard.double(forKey: PreferencesKeys.typingSpeed)
         let speed = cps > 0 ? cps : 15.0
 
+        // Fast-path: try AX value injection (instant insert) before typing keystrokes
+        if AXValueInjector.trySetValue(text) {
+            return
+        }
+
         // Cancel any existing session
         session?.cancel()
 

--- a/Sources/ClippyTyperApp/AppDelegate.swift
+++ b/Sources/ClippyTyperApp/AppDelegate.swift
@@ -106,7 +106,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let list = UserDefaults.standard.array(forKey: PreferencesKeys.perAppExceptions) as? [String] ?? []
             if list.contains(active) {
                 NSLog("ClippyTyper: Skipping typing for excluded app: \(active)")
-                NSBeep()
+                NSSound.beep()
                 return
             }
         }

--- a/Sources/ClippyTyperApp/AppDelegate.swift
+++ b/Sources/ClippyTyperApp/AppDelegate.swift
@@ -14,6 +14,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var permissionsWindow: PermissionsWindowController?
     private var session: TypingSession?
     private var keyboardMonitor: KeyboardEventMonitor?
+    private var progressHUD: ProgressHUD?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         PreferencesDefaults.register()

--- a/Sources/ClippyTyperApp/LoginItemManager.swift
+++ b/Sources/ClippyTyperApp/LoginItemManager.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+#if canImport(ServiceManagement)
+import ServiceManagement
+#endif
+
+enum LoginItemManagerError: Error, CustomStringConvertible {
+    case unsupported
+    case helperIdentifierMissing
+    case smAppService(String)
+
+    var description: String {
+        switch self {
+        case .unsupported: return "Login item not supported in this environment"
+        case .helperIdentifierMissing: return "Helper identifier missing"
+        case .smAppService(let msg): return msg
+        }
+    }
+}
+
+enum LoginItemManager {
+    // Update if you change the helper target bundle id in Xcode
+    static let helperBundleIdentifier = "com.clippytyper.helper"
+
+    private static var isBundledApp: Bool {
+        // Simple check: running from an .app bundle
+        Bundle.main.bundlePath.hasSuffix(".app")
+    }
+
+    static func isEnabled() -> Bool {
+        #if canImport(ServiceManagement)
+        if #available(macOS 13.0, *) {
+            if isBundledApp {
+                let service = SMAppService.loginItem(identifier: helperBundleIdentifier)
+                switch service.status {
+                case .enabled: return true
+                default: break
+                }
+            }
+        }
+        #endif
+        return LaunchAtLoginManager.isEnabled()
+    }
+
+    static func setEnabled(_ enabled: Bool) throws {
+        #if canImport(ServiceManagement)
+        if #available(macOS 13.0, *) {
+            if isBundledApp {
+                let service = SMAppService.loginItem(identifier: helperBundleIdentifier)
+                do {
+                    if enabled { try service.register() } else { try service.unregister() }
+                    return
+                } catch {
+                    throw LoginItemManagerError.smAppService(String(describing: error))
+                }
+            }
+        }
+        #endif
+        // Fallback to LaunchAgent approach in dev/SwiftPM
+        try LaunchAtLoginManager.setEnabled(enabled)
+    }
+}
+

--- a/Sources/ClippyTyperApp/MenuBarController.swift
+++ b/Sources/ClippyTyperApp/MenuBarController.swift
@@ -9,6 +9,7 @@ final class MenuBarController: NSObject {
     var onOpenPreferences: (() -> Void)?
     var onOpenHelp: (() -> Void)?
     var onOpenPermissions: (() -> Void)?
+    var onExcludeCurrentApp: (() -> Void)?
     var onQuit: (() -> Void)?
 
     private var pauseItem: NSMenuItem!
@@ -41,6 +42,12 @@ final class MenuBarController: NSObject {
 
         menu.addItem(NSMenuItem.separator())
 
+        let excludeItem = NSMenuItem(title: "Exclude Current App", action: #selector(excludeCurrentApp), keyEquivalent: "")
+        excludeItem.target = self
+        menu.addItem(excludeItem)
+
+        menu.addItem(NSMenuItem.separator())
+
         let prefsItem = NSMenuItem(title: "Preferences…", action: #selector(openPreferences), keyEquivalent: ",")
         prefsItem.target = self
         menu.addItem(prefsItem)
@@ -65,6 +72,7 @@ final class MenuBarController: NSObject {
     @objc private func startTyping() { onStartTyping?() }
     @objc private func pauseResume() { onPauseResume?() }
     @objc private func cancelTyping() { onCancel?() }
+    @objc private func excludeCurrentApp() { onExcludeCurrentApp?() }
     @objc private func openPreferences() { onOpenPreferences?() }
     @objc private func openPermissions() { onOpenPermissions?() }
     @objc private func openHelp() { onOpenHelp?() }

--- a/Sources/ClippyTyperApp/MenuBarController.swift
+++ b/Sources/ClippyTyperApp/MenuBarController.swift
@@ -13,6 +13,7 @@ final class MenuBarController: NSObject {
     var onQuit: (() -> Void)?
 
     private var pauseItem: NSMenuItem!
+    private var baseTitle: String = "Clippy"
 
     override init() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -22,7 +23,7 @@ final class MenuBarController: NSObject {
 
     private func constructMenu() {
         if let button = statusItem.button {
-            button.title = "Clippy"
+            button.title = baseTitle
             button.setAccessibilityLabel("ClippyTyper")
         }
         let menu = NSMenu()
@@ -80,5 +81,15 @@ final class MenuBarController: NSObject {
 
     func setPaused(_ paused: Bool) {
         pauseItem.title = paused ? "Resume Typing" : "Pause Typing"
+    }
+
+    func setProgress(_ fraction: Double?) {
+        guard let button = statusItem.button else { return }
+        if let f = fraction {
+            let pct = Int((f * 100).rounded())
+            button.title = "\(baseTitle) \(pct)%"
+        } else {
+            button.title = baseTitle
+        }
     }
 }

--- a/Sources/ClippyTyperApp/PreferencesWindow.swift
+++ b/Sources/ClippyTyperApp/PreferencesWindow.swift
@@ -42,6 +42,12 @@ final class PreferencesViewController: NSViewController {
         let b = NSButton(checkboxWithTitle: "Launch at login", target: nil, action: nil)
         return b
     }()
+    private let loginStatusLabel: NSTextField = {
+        let tf = NSTextField(labelWithString: "")
+        tf.textColor = .secondaryLabelColor
+        tf.lineBreakMode = .byTruncatingTail
+        return tf
+    }()
 
     private let emergencyCancelCheckbox: NSButton = {
         let b = NSButton(checkboxWithTitle: "Enable emergency cancel (Esc×2 / ctrl+opt+cmd+Esc)", target: nil, action: nil)
@@ -89,6 +95,7 @@ final class PreferencesViewController: NSViewController {
         // Prefer actual system state (SMAppService when bundled; fallback to LaunchAgent)
         let sysEnabled = LoginItemManager.isEnabled()
         launchAtLoginCheckbox.state = sysEnabled ? .on : (defaults.bool(forKey: PreferencesKeys.launchAtLogin) ? .on : .off)
+        updateLoginStatusLabel(enabled: sysEnabled)
         emergencyCancelCheckbox.state = defaults.bool(forKey: PreferencesKeys.emergencyCancelEnabled) ? .on : .off
         let dpw = defaults.double(forKey: PreferencesKeys.emergencyCancelDoublePressWindow)
         doublePressSlider.doubleValue = (dpw > 0 ? dpw : 0.4)
@@ -102,6 +109,7 @@ final class PreferencesViewController: NSViewController {
          emergencyCancelCheckbox,
          doublePressLabel, doublePressSlider, doublePressValueLabel,
          instantPasteFallbackCheckbox,
+         loginStatusLabel,
          exclusionsLabel, exclusionsScroll, excludeCurrentButton, removeSelectedButton, clearExclusionsButton].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview($0)
@@ -150,6 +158,10 @@ final class PreferencesViewController: NSViewController {
 
             instantPasteFallbackCheckbox.topAnchor.constraint(equalTo: doublePressSlider.bottomAnchor, constant: 16),
             instantPasteFallbackCheckbox.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),
+
+            loginStatusLabel.centerYAnchor.constraint(equalTo: launchAtLoginCheckbox.centerYAnchor),
+            loginStatusLabel.leadingAnchor.constraint(equalTo: launchAtLoginCheckbox.trailingAnchor, constant: 12),
+            loginStatusLabel.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20),
 
             exclusionsLabel.topAnchor.constraint(equalTo: instantPasteFallbackCheckbox.bottomAnchor, constant: 16),
             exclusionsLabel.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),
@@ -233,6 +245,7 @@ final class PreferencesViewController: NSViewController {
         do {
             try LoginItemManager.setEnabled(enabled)
             UserDefaults.standard.set(enabled, forKey: PreferencesKeys.launchAtLogin)
+            updateLoginStatusLabel(enabled: enabled)
             onLaunchAtLoginChanged?(enabled)
         } catch {
             let alert = NSAlert()
@@ -241,7 +254,10 @@ final class PreferencesViewController: NSViewController {
             alert.informativeText = String(describing: error)
             alert.addButton(withTitle: "OK")
             alert.runModal()
-            launchAtLoginCheckbox.state = LoginItemManager.isEnabled() ? .on : .off
+            let current = LoginItemManager.isEnabled()
+            launchAtLoginCheckbox.state = current ? .on : .off
+            loginStatusLabel.stringValue = "Login item error: \(error)"
+            loginStatusLabel.textColor = .systemRed
         }
     }
 
@@ -249,6 +265,11 @@ final class PreferencesViewController: NSViewController {
         let enabled = (emergencyCancelCheckbox.state == .on)
         UserDefaults.standard.set(enabled, forKey: PreferencesKeys.emergencyCancelEnabled)
         onEmergencyCancelEnabledChanged?(enabled)
+    }
+
+    private func updateLoginStatusLabel(enabled: Bool) {
+        loginStatusLabel.stringValue = enabled ? "Login item: Enabled" : "Login item: Disabled"
+        loginStatusLabel.textColor = .secondaryLabelColor
     }
 
     @objc private func onDoublePressWindowSliderChanged() {

--- a/Sources/ClippyTyperApp/PreferencesWindow.swift
+++ b/Sources/ClippyTyperApp/PreferencesWindow.swift
@@ -86,8 +86,8 @@ final class PreferencesViewController: NSViewController {
         speedValueLabel.stringValue = String(Int(speedSlider.doubleValue))
         let currentHotkey = defaults.string(forKey: PreferencesKeys.hotkey) ?? "ctrl+opt+t"
         hotkeyField.stringValue = currentHotkey
-        // Prefer actual system state; fall back to stored pref
-        let sysEnabled = LaunchAtLoginManager.isEnabled()
+        // Prefer actual system state (SMAppService when bundled; fallback to LaunchAgent)
+        let sysEnabled = LoginItemManager.isEnabled()
         launchAtLoginCheckbox.state = sysEnabled ? .on : (defaults.bool(forKey: PreferencesKeys.launchAtLogin) ? .on : .off)
         emergencyCancelCheckbox.state = defaults.bool(forKey: PreferencesKeys.emergencyCancelEnabled) ? .on : .off
         let dpw = defaults.double(forKey: PreferencesKeys.emergencyCancelDoublePressWindow)
@@ -231,7 +231,7 @@ final class PreferencesViewController: NSViewController {
     @objc private func onLaunchAtLoginToggled() {
         let enabled = (launchAtLoginCheckbox.state == .on)
         do {
-            try LaunchAtLoginManager.setEnabled(enabled)
+            try LoginItemManager.setEnabled(enabled)
             UserDefaults.standard.set(enabled, forKey: PreferencesKeys.launchAtLogin)
             onLaunchAtLoginChanged?(enabled)
         } catch {
@@ -241,7 +241,7 @@ final class PreferencesViewController: NSViewController {
             alert.informativeText = String(describing: error)
             alert.addButton(withTitle: "OK")
             alert.runModal()
-            launchAtLoginCheckbox.state = LaunchAtLoginManager.isEnabled() ? .on : .off
+            launchAtLoginCheckbox.state = LoginItemManager.isEnabled() ? .on : .off
         }
     }
 

--- a/Sources/ClippyTyperApp/PreferencesWindow.swift
+++ b/Sources/ClippyTyperApp/PreferencesWindow.swift
@@ -4,9 +4,10 @@ import ClippyTyperPreferences
 final class PreferencesWindowController: NSWindowController {
     init(contentViewController: NSViewController) {
         let window = NSWindow(contentViewController: contentViewController)
-        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.title = "Preferences"
-        window.setContentSize(NSSize(width: 440, height: 320))
+        window.setContentSize(NSSize(width: 560, height: 520))
+        window.minSize = NSSize(width: 520, height: 420)
         super.init(window: window)
     }
 
@@ -156,7 +157,7 @@ final class PreferencesViewController: NSViewController {
             exclusionsScroll.topAnchor.constraint(equalTo: exclusionsLabel.bottomAnchor, constant: 8),
             exclusionsScroll.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),
             exclusionsScroll.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            exclusionsScroll.heightAnchor.constraint(equalToConstant: 120),
+            exclusionsScroll.heightAnchor.constraint(equalToConstant: 240),
 
             excludeCurrentButton.topAnchor.constraint(equalTo: exclusionsScroll.bottomAnchor, constant: 8),
             excludeCurrentButton.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),

--- a/Sources/ClippyTyperApp/PreferencesWindow.swift
+++ b/Sources/ClippyTyperApp/PreferencesWindow.swift
@@ -157,10 +157,10 @@ final class PreferencesViewController: NSViewController {
             exclusionsScroll.topAnchor.constraint(equalTo: exclusionsLabel.bottomAnchor, constant: 8),
             exclusionsScroll.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),
             exclusionsScroll.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            exclusionsScroll.heightAnchor.constraint(equalToConstant: 240),
 
             excludeCurrentButton.topAnchor.constraint(equalTo: exclusionsScroll.bottomAnchor, constant: 8),
             excludeCurrentButton.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),
+            excludeCurrentButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -20),
 
             removeSelectedButton.centerYAnchor.constraint(equalTo: excludeCurrentButton.centerYAnchor),
             removeSelectedButton.leadingAnchor.constraint(equalTo: excludeCurrentButton.trailingAnchor, constant: 8),

--- a/Sources/ClippyTyperApp/PreferencesWindow.swift
+++ b/Sources/ClippyTyperApp/PreferencesWindow.swift
@@ -56,6 +56,15 @@ final class PreferencesViewController: NSViewController {
         return b
     }()
 
+    // Exclusions UI
+    private let exclusionsLabel = NSTextField(labelWithString: "Excluded apps (bundle IDs)")
+    private let exclusionsScroll = NSScrollView()
+    private let exclusionsTable = NSTableView()
+    private let excludeCurrentButton = NSButton(title: "Exclude Current App", target: nil, action: nil)
+    private let removeSelectedButton = NSButton(title: "Remove Selected", target: nil, action: nil)
+    private let clearExclusionsButton = NSButton(title: "Clear All", target: nil, action: nil)
+    private var exclusions: [String] = []
+
     var onTypingSpeedChanged: ((Double) -> Void)?
     var onHotkeyChanged: ((String) -> Void)?
     var onLaunchAtLoginChanged: ((Bool) -> Void)?
@@ -86,7 +95,13 @@ final class PreferencesViewController: NSViewController {
         instantPasteFallbackCheckbox.state = defaults.bool(forKey: PreferencesKeys.instantPasteFallback) ? .on : .off
 
         // Build layout
-        [speedLabel, speedSlider, speedValueLabel, hotkeyLabel, hotkeyField, applyHotkeyButton, hotkeyStatusLabel, launchAtLoginCheckbox, emergencyCancelCheckbox, doublePressLabel, doublePressSlider, doublePressValueLabel, instantPasteFallbackCheckbox].forEach {
+        [speedLabel, speedSlider, speedValueLabel,
+         hotkeyLabel, hotkeyField, applyHotkeyButton, hotkeyStatusLabel,
+         launchAtLoginCheckbox,
+         emergencyCancelCheckbox,
+         doublePressLabel, doublePressSlider, doublePressValueLabel,
+         instantPasteFallbackCheckbox,
+         exclusionsLabel, exclusionsScroll, excludeCurrentButton, removeSelectedButton, clearExclusionsButton].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview($0)
         }
@@ -133,7 +148,24 @@ final class PreferencesViewController: NSViewController {
             doublePressValueLabel.leadingAnchor.constraint(equalTo: doublePressSlider.trailingAnchor, constant: 8),
 
             instantPasteFallbackCheckbox.topAnchor.constraint(equalTo: doublePressSlider.bottomAnchor, constant: 16),
-            instantPasteFallbackCheckbox.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor)
+            instantPasteFallbackCheckbox.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),
+
+            exclusionsLabel.topAnchor.constraint(equalTo: instantPasteFallbackCheckbox.bottomAnchor, constant: 16),
+            exclusionsLabel.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),
+
+            exclusionsScroll.topAnchor.constraint(equalTo: exclusionsLabel.bottomAnchor, constant: 8),
+            exclusionsScroll.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),
+            exclusionsScroll.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            exclusionsScroll.heightAnchor.constraint(equalToConstant: 120),
+
+            excludeCurrentButton.topAnchor.constraint(equalTo: exclusionsScroll.bottomAnchor, constant: 8),
+            excludeCurrentButton.leadingAnchor.constraint(equalTo: speedLabel.leadingAnchor),
+
+            removeSelectedButton.centerYAnchor.constraint(equalTo: excludeCurrentButton.centerYAnchor),
+            removeSelectedButton.leadingAnchor.constraint(equalTo: excludeCurrentButton.trailingAnchor, constant: 8),
+
+            clearExclusionsButton.centerYAnchor.constraint(equalTo: excludeCurrentButton.centerYAnchor),
+            clearExclusionsButton.leadingAnchor.constraint(equalTo: removeSelectedButton.trailingAnchor, constant: 8)
         ])
 
         // Wire actions
@@ -150,7 +182,18 @@ final class PreferencesViewController: NSViewController {
         instantPasteFallbackCheckbox.target = self
         instantPasteFallbackCheckbox.action = #selector(onInstantPasteFallbackToggled)
 
+        excludeCurrentButton.target = self
+        excludeCurrentButton.action = #selector(onExcludeCurrentApp)
+        removeSelectedButton.target = self
+        removeSelectedButton.action = #selector(onRemoveSelected)
+        clearExclusionsButton.target = self
+        clearExclusionsButton.action = #selector(onClearExclusions)
+
         NotificationCenter.default.addObserver(self, selector: #selector(onHotkeyRegistrationResult(_:)), name: .hotkeyRegistrationResult, object: nil)
+
+        // Exclusions table setup
+        setupExclusionsTable()
+        loadExclusions()
     }
 
     @objc private func onInstantPasteFallbackToggled() {
@@ -213,5 +256,77 @@ final class PreferencesViewController: NSViewController {
         doublePressValueLabel.stringValue = String(format: "%.1f", val)
         UserDefaults.standard.set(val, forKey: PreferencesKeys.emergencyCancelDoublePressWindow)
         onDoublePressWindowChanged?(val)
+    }
+
+    // MARK: - Exclusions
+
+    private func setupExclusionsTable() {
+        let col = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("BundleID"))
+        col.title = "Bundle ID"
+        col.width = 380
+        exclusionsTable.addTableColumn(col)
+        exclusionsTable.headerView = nil
+        exclusionsTable.usesAlternatingRowBackgroundColors = true
+        exclusionsTable.allowsMultipleSelection = true
+        exclusionsTable.delegate = self
+        exclusionsTable.dataSource = self
+        exclusionsScroll.documentView = exclusionsTable
+        exclusionsScroll.hasVerticalScroller = true
+        exclusionsScroll.borderType = .bezelBorder
+    }
+
+    private func loadExclusions() {
+        exclusions = (UserDefaults.standard.array(forKey: PreferencesKeys.perAppExceptions) as? [String] ?? [])
+        exclusionsTable.reloadData()
+    }
+
+    private func saveExclusions() {
+        UserDefaults.standard.set(exclusions, forKey: PreferencesKeys.perAppExceptions)
+        exclusionsTable.reloadData()
+    }
+
+    @objc private func onExcludeCurrentApp() {
+        guard let active = NSWorkspace.shared.frontmostApplication?.bundleIdentifier else { return }
+        if !exclusions.contains(active) {
+            exclusions.append(active)
+            exclusions.sort()
+            saveExclusions()
+        }
+    }
+
+    @objc private func onRemoveSelected() {
+        let rows = exclusionsTable.selectedRowIndexes
+        guard !rows.isEmpty else { return }
+        exclusions = exclusions.enumerated().filter { !rows.contains($0.offset) }.map { $0.element }
+        saveExclusions()
+    }
+
+    @objc private func onClearExclusions() {
+        exclusions.removeAll()
+        saveExclusions()
+    }
+}
+
+extension PreferencesViewController: NSTableViewDataSource, NSTableViewDelegate {
+    func numberOfRows(in tableView: NSTableView) -> Int { exclusions.count }
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let id = NSUserInterfaceItemIdentifier("Cell")
+        let cell = tableView.makeView(withIdentifier: id, owner: self) as? NSTableCellView ?? {
+            let v = NSTableCellView()
+            v.identifier = id
+            let tf = NSTextField(labelWithString: "")
+            tf.translatesAutoresizingMaskIntoConstraints = false
+            v.addSubview(tf)
+            v.textField = tf
+            NSLayoutConstraint.activate([
+                tf.leadingAnchor.constraint(equalTo: v.leadingAnchor, constant: 6),
+                tf.trailingAnchor.constraint(equalTo: v.trailingAnchor, constant: -6),
+                tf.topAnchor.constraint(equalTo: v.topAnchor, constant: 2),
+                tf.bottomAnchor.constraint(equalTo: v.bottomAnchor, constant: -2)
+            ])
+            return v
+        }()
+        cell.textField?.stringValue = exclusions[row]
+        return cell
     }
 }

--- a/Sources/ClippyTyperApp/ProgressHUD.swift
+++ b/Sources/ClippyTyperApp/ProgressHUD.swift
@@ -1,0 +1,73 @@
+import AppKit
+
+final class ProgressHUD: NSWindowController {
+    private let titleLabel = NSTextField(labelWithString: "Typing… 0%")
+    private let statusLabel = NSTextField(labelWithString: "")
+
+    init() {
+        let content = NSView()
+        content.wantsLayer = true
+        content.layer?.cornerRadius = 12
+        content.layer?.backgroundColor = NSColor.windowBackgroundColor.withAlphaComponent(0.9).cgColor
+
+        let window = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 260, height: 120),
+                             styleMask: [.titled, .fullSizeContentView],
+                             backing: .buffered,
+                             defer: false)
+        window.isMovableByWindowBackground = true
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.level = .floating
+        window.hidesOnDeactivate = false
+        window.isReleasedWhenClosed = false
+        window.contentView = content
+
+        super.init(window: window)
+
+        titleLabel.font = .systemFont(ofSize: 16, weight: .semibold)
+        titleLabel.alignment = .center
+        statusLabel.font = .systemFont(ofSize: 12)
+        statusLabel.alignment = .center
+
+        [titleLabel, statusLabel].forEach { v in
+            v.translatesAutoresizingMaskIntoConstraints = false
+            content.addSubview(v)
+        }
+
+        NSLayoutConstraint.activate([
+            titleLabel.centerXAnchor.constraint(equalTo: content.centerXAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: content.centerYAnchor, constant: -12),
+
+            statusLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 6),
+            statusLabel.centerXAnchor.constraint(equalTo: content.centerXAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func show() {
+        guard let screen = NSScreen.main else { window?.makeKeyAndOrderFront(nil); return }
+        if let w = window {
+            let frame = w.frame
+            let x = screen.frame.midX - frame.width / 2
+            let y = screen.frame.midY - frame.height / 2
+            w.setFrameOrigin(NSPoint(x: x, y: y))
+            w.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    func hide() {
+        window?.orderOut(nil)
+    }
+
+    func update(progress fraction: Double?, paused: Bool) {
+        if let f = fraction {
+            let pct = Int((f * 100).rounded())
+            titleLabel.stringValue = paused ? "Paused… \(pct)%" : "Typing… \(pct)%"
+        } else {
+            titleLabel.stringValue = paused ? "Paused" : "Typing…"
+        }
+        statusLabel.stringValue = "Press ctrl+opt+esc to pause, ctrl+opt+cmd+esc to cancel"
+    }
+}
+

--- a/Sources/ClippyTyperApp/TypingSession.swift
+++ b/Sources/ClippyTyperApp/TypingSession.swift
@@ -10,6 +10,7 @@ final class TypingSession {
     private let engine: TypingEngine
     private let queue = DispatchQueue(label: "TypingSession.queue")
     private let state: State
+    private let sender: KeystrokeSender
 
     var isPaused: Bool { state.isPaused }
     var isCancelled: Bool { state.isCancelled }
@@ -21,6 +22,7 @@ final class TypingSession {
         let cancellableSender = CancellableSender(underlying: baseSender) {
             state.isCancelled
         }
+        self.sender = cancellableSender
         // Inject a sleep that respects pause/cancel in small increments
         func controlledSleep(_ d: TimeInterval) {
             if d <= 0 {
@@ -47,11 +49,49 @@ final class TypingSession {
         self.engine = TypingEngine(sender: cancellableSender, sleep: controlledSleep)
     }
 
-    func start(text: String, cps: Double, completion: @escaping (Result<Void, Error>) -> Void) {
+    func start(text: String, cps: Double, progress: ((Double) -> Void)? = nil, completion: @escaping (Result<Void, Error>) -> Void) {
         queue.async { [weak self] in
             guard let self else { return }
+            let events = self.engine.plan(text: text, cps: cps)
+            let total = max(1, events.count)
+            var idx = 0
             do {
-                try self.engine.type(text: text, cps: cps)
+                for event in events {
+                    if self.state.isCancelled { throw KeystrokeError.sendFailed("Cancelled") }
+                    // sleep respecting pause/cancel
+                    if event.delay > 0 {
+                        var remaining = event.delay
+                        while remaining > 0 {
+                            if self.state.isCancelled { throw KeystrokeError.sendFailed("Cancelled") }
+                            if self.state.isPaused { Thread.sleep(forTimeInterval: 0.01); continue }
+                            let step = min(0.01, remaining)
+                            Thread.sleep(forTimeInterval: step)
+                            remaining -= step
+                        }
+                    } else {
+                        // handle pause even when delay is 0
+                        while self.state.isPaused {
+                            if self.state.isCancelled { throw KeystrokeError.sendFailed("Cancelled") }
+                            Thread.sleep(forTimeInterval: 0.01)
+                        }
+                    }
+
+                    var attempt = 0
+                    let maxRetries = 3
+                    let baseBackoff = 0.03
+                    while true {
+                        do {
+                            try self.sender.send(character: event.character)
+                            break
+                        } catch {
+                            if attempt >= maxRetries { throw error }
+                            Thread.sleep(forTimeInterval: baseBackoff * pow(2.0, Double(attempt)))
+                            attempt += 1
+                        }
+                    }
+                    idx += 1
+                    progress?(Double(idx) / Double(total))
+                }
                 completion(.success(()))
             } catch {
                 completion(.failure(error))

--- a/Sources/ClippyTyperHelper/main.swift
+++ b/Sources/ClippyTyperHelper/main.swift
@@ -1,0 +1,11 @@
+import AppKit
+
+@main
+final class HelperMain: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Typical login item helper would ping the main app, then exit.
+        // For now, do nothing and quit; this stub allows SMAppService to register.
+        NSApp.terminate(nil)
+    }
+}
+

--- a/Sources/ClippyTyperPreferences/RegisterDefaults.swift
+++ b/Sources/ClippyTyperPreferences/RegisterDefaults.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Registers sensible defaults at app launch.
+public enum PreferencesDefaults {
+    public static let values: [String: Any] = [
+        PreferencesKeys.typingSpeed: 15.0,
+        PreferencesKeys.hotkey: "ctrl+opt+t",
+        PreferencesKeys.launchAtLogin: false,
+        PreferencesKeys.emergencyCancelEnabled: true,
+        PreferencesKeys.emergencyCancelDoublePressWindow: 0.4,
+        PreferencesKeys.instantPasteFallback: false,
+        PreferencesKeys.perAppExceptions: []
+    ]
+
+    public static func register() {
+        UserDefaults.standard.register(defaults: values)
+    }
+}
+

--- a/Sources/ClippyTyperPreferences/UserDefaultsKeys.swift
+++ b/Sources/ClippyTyperPreferences/UserDefaultsKeys.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Centralized keys for UserDefaults. Keep in sync with PRD features.
+public enum PreferencesKeys {
+    public static let typingSpeed = "typingSpeed"           // Double (characters per second)
+    public static let hotkey = "hotkey"                     // String (e.g., "ctrl+opt+t"); app-defined format
+    public static let launchAtLogin = "launchAtLogin"       // Bool
+    public static let emergencyCancelEnabled = "emergencyCancelEnabled" // Bool
+    public static let emergencyCancelDoublePressWindow = "emergencyCancelDoublePressWindow" // Double (seconds)
+    public static let instantPasteFallback = "instantPasteFallback" // Bool
+    public static let perAppExceptions = "perAppExceptions"         // [String] (bundle identifiers)
+}
+

--- a/implementationplan.md
+++ b/implementationplan.md
@@ -50,7 +50,7 @@ Deliver a macOS Sonoma-focused menu bar utility that types plain-text clipboard 
 - [x] Permissions onboarding flow (permissions window + auto-prompt) [PR: #___] [Commit: ___] (2025-09-05)
 - [ ] Instant paste fallback (optional) [PR: #___]
 - [x] Pause/resume and cancel shortcuts [PR: #___] [Commit: ___] (2025-09-05)
-- [ ] Per-app exceptions by bundle id (optional) [PR: #___]
+- [x] Per-app exceptions by bundle id (menu: Exclude Current App; skip at runtime) [PR: #2] [Commit: ___] (2025-09-06)
 - [ ] Performance validation: idle CPU/mem, large text reliability [PR: #___]
 - [ ] Packaging: entitlements, codesign, notarization (as applicable) [PR: #___]
 - [ ] Release notes and screenshots/GIFs [PR: #___]

--- a/xcode/HelperInfo.plist
+++ b/xcode/HelperInfo.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>LSBackgroundOnly</key>
+    <true/>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/xcode/Info.plist
+++ b/xcode/Info.plist
@@ -15,9 +15,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
+    <string>0.1.1</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
     <key>LSBackgroundOnly</key>
     <true/>
     <key>LSUIElement</key>

--- a/xcode/project.yml
+++ b/xcode/project.yml
@@ -34,6 +34,22 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CODE_SIGN_STYLE: Automatic
+    dependencies:
+      - target: ClippyTyperHelper
+        embed: true
+        embedLinked: true
+  ClippyTyperHelper:
+    type: application
+    platform: macOS
+    info:
+      path: xcode/HelperInfo.plist
+      properties:
+        CFBundleIdentifier: com.clippytyper.helper
+        CFBundleName: ClippyTyperHelper
+        LSBackgroundOnly: true
+        LSUIElement: true
+    sources:
+      - path: ../Sources/ClippyTyperHelper
   ClippyTyperUITests:
     type: bundle.ui-testing
     platform: macOS

--- a/xcode/project.yml
+++ b/xcode/project.yml
@@ -14,8 +14,8 @@ targets:
       properties:
         CFBundleIdentifier: com.clippytyper.app
         CFBundleName: ClippyTyper
-        CFBundleShortVersionString: 1.0
-        CFBundleVersion: 1
+        CFBundleShortVersionString: 0.1.1
+        CFBundleVersion: 2
         LSBackgroundOnly: true
         LSUIElement: true
         CFBundleURLTypes:

--- a/xcode/project.yml
+++ b/xcode/project.yml
@@ -38,7 +38,7 @@ targets:
     type: bundle.ui-testing
     platform: macOS
     sources:
-      - path: xcode/UITests
+      - path: UITests
     dependencies:
       - target: ClippyTyper
 schemes:


### PR DESCRIPTION
Release v0.1.1\n\nHighlights\n- Per‑App Exceptions: skip typing in selected apps; manage list in Preferences (add/remove/clear) and via “Exclude Current App”.\n- Typing Progress: menu bar percentage and a floating HUD with pause/cancel hints.\n- Instant Paste Fallback: engage only when typing fails; try AX value insert first, then Cmd+V.\n- Login at Login: SMAppService helper for bundled app; LaunchAgent fallback for SwiftPM dev.\n- Preferences: larger/resizable window; inline login item status/errors.\n- CI: self‑hosted runner; keep Xcode build/test + lint; remove unstable SwiftPM job.\n\nChecklist\n- [x] CHANGELOG updated (v0.1.1)\n- [x] Xcode build/test passing on self‑hosted runner\n- [x] Lint job succeeds\n- [ ] Merge PR into main\n- [ ] Tag v0.1.1 on main and publish release\n\nNotes for learners\n- PR merges your branch into main. After merge, we tag v0.1.1 and draft the release.